### PR TITLE
Updated template code to contain wrapper element

### DIFF
--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -450,17 +450,13 @@ define([
                     elId,
                     $(this.selectedElementMarkup).html(markup).get(0).outerHTML,
                     function() {
-                        appApi.Editor.addClasses(elId, ['dp-imbo-image']);
                         appApi.Editor.markAsActive(elId);
                     }
                 );
             } else {
                 appApi.Editor.insertElement(
                     markup,
-                    { select: true },
-                    function(elId) {
-                        appApi.Editor.addClasses(elId, ['dp-imbo-image']);
-                    }
+                    { select: true }
                 );
             }
 

--- a/js/template.js
+++ b/js/template.js
@@ -13,13 +13,15 @@ define(['underscore'], function(_) {
      */
 
     var defaultTemplate = _.template([
-        '<div class="dp-article-image-container">',
-        '   <img src="<%= url %>" width="<%= width %>" alt="<%- title %>" data-transformations="<%- transformations %>" data-image-identifier="<%- imageIdentifier %>" data-crop-parameters="<%- cropParams %>" data-crop-aspect-ratio="<%- cropRatio %>">',
-        '   <div class="dp-article-image-title" data-dp-editable-type="textfield" data-dp-editable-name="Title"><%- title %></div>',
-        '   <div class="dp-article-image-description" data-dp-editable-type="html" data-dp-editable-name="Description"><%- description %></div>',
-        '   <div class="dp-article-image-byline">',
-        '       <span class="dp-article-image-author" data-dp-editable-type="textfield" data-dp-editable-name="Author"><%- author %></span>',
-        '       <span class="dp-article-image-source" data-dp-editable-type="textfield" data-dp-editable-name="Source"><%- source %></span>',
+        '<div id="imbo-image-<%- imageIdentifier %>" class="dp-plugin-element dp-imbo-image" data-external-id="<%- imageIdentifier %>">',
+        '    <div class="dp-article-image-container" >',
+        '       <img src="<%= url %>" width="<%= width %>" alt="<%- title %>" data-transformations="<%- transformations %>" data-image-identifier="<%- imageIdentifier %>" data-crop-parameters="<%- cropParams %>" data-crop-aspect-ratio="<%- cropRatio %>">',
+        '       <div class="dp-article-image-title" data-dp-editable-type="textfield" data-dp-editable-name="Title"><%- title %></div>',
+        '       <div class="dp-article-image-description" data-dp-editable-type="html" data-dp-editable-name="Description"><%- description %></div>',
+        '       <div class="dp-article-image-byline">',
+        '           <span class="dp-article-image-author" data-dp-editable-type="textfield" data-dp-editable-name="Author"><%- author %></span>',
+        '           <span class="dp-article-image-source" data-dp-editable-type="textfield" data-dp-editable-name="Source"><%- source %></span>',
+        '        </div>',
         '    </div>',
         '</div>'
     ].join('\n'));


### PR DESCRIPTION
Updated the template code to contain the whole wrapper element. Makes it a bit easier to add classes to it, like the `dp-imbo-image` class, as well as adding the `data-external-id` attribute. 
