### PR TITLE
First iteration of UX tweaks

### DIFF
--- a/css/imbo-plugin.css
+++ b/css/imbo-plugin.css
@@ -346,6 +346,25 @@ button.upload-scanpix-image {
 }
 
 
+
+/* META INFO in image-list */
+
+.meta-info {
+    position: absolute;
+    top: 40px;
+    z-index: 100;
+    min-height: 150px;
+    width: 205.5%;
+    color: #ddd;
+    background: #222;
+    text-align: left;
+}
+
+.meta-info dt {
+    display: none;
+}
+
+
 /* Progress bar */
 
 .progress {

--- a/css/imbo-plugin.css
+++ b/css/imbo-plugin.css
@@ -1,7 +1,7 @@
 /* Semi-defaults from Aptoma */
 body.editor-view {
     background-color: #444;
-    color: #CCC;
+    color: #ccc;
 }
 
 
@@ -24,13 +24,27 @@ button, div.button {
 }
 
 
+/* Utility classes */
+
 .droppable {
     background: #baeebc;
 }
 
 .hidden {
-    display: none;
+    display: none !important;
 }
+
+.clear:before, .clear:after {
+    content: " ";
+    display: table;
+}
+
+.clear:after {
+    clear: both;
+}
+
+
+/* INITIAL STATE - LOADING CONTENT (hide while loading) */
 
 .loading .content, .loading .meta-editor {
     display: none;
@@ -44,9 +58,14 @@ button, div.button {
     display: block;
 }
 
+/* CONTENT - first panel (add image, choose image) */
+
+
+/* Adding new images */
+
 fieldset.add-new-images {
     position: relative;
-    min-height: 55px;
+    padding-bottom: 30px;
 }
 
 .file-upload {
@@ -60,6 +79,7 @@ button.upload-scanpix-image {
     width: 225px;
     height: 30px;
     position: absolute;
+    cursor: pointer;
 }
 
 .file-upload, button.upload-local-file {
@@ -70,13 +90,9 @@ button.upload-scanpix-image {
     left: 250px;
 }
 
-.spacer {
-    visibility: hidden;
-    display: inline-block;
-    height: 30px;
+.file-upload:hover + .upload-local-file {
+    opacity: 1;
 }
-
-button.upload-local-file {}
 
 fieldset.current-images {
     padding: 0 0 0 12px;
@@ -85,12 +101,19 @@ fieldset.current-images {
 
 .search .image-search {
     width: 60%;
-    line-height: 25px;
+    float: left;
 }
 
 .search button {
     margin-left: 5px;
 }
+
+.search-stats {
+    margin-bottom: 6px;
+}
+
+
+/* IMAGE LIST  */
 
 .image-list {
     list-style-type: none;
@@ -129,32 +152,31 @@ fieldset.current-images {
     background: #fff;
 }
 
-.clear:before, .clear:after {
-    content: " ";
-    display: table;
-}
-
-.clear:after {
-    clear: both;
-}
 
 .image-list li {
     position: relative;
     float: left;
     width: 30.65%;
     margin: 5px;
-    height: 160px;
+    padding-bottom: 30px; /* will be occupied by image-toolbar */
+    height: 130px;
     background: #fff;
     border: 1px solid #DDD;
+
     display: -webkit-flexbox;
     display: -ms-flexbox;
     display: -webkit-flex;
     display: flex;
+
     -webkit-flex-align: center;
     -ms-flex-align: center;
     -webkit-align-items: center;
     align-items: center;
     text-align: center;
+
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
 }
 
 .image-list .full-image {
@@ -163,19 +185,57 @@ fieldset.current-images {
 
 .image-list .full-image img {
     max-width: 100%;
+    max-height: 120px;
 }
 
-.image-toolbar {
+.image-list .insert-image {
     display: none;
+}
+
+.image-list.insertion-enabled .insert-image {
+    display: inline;
+}
+
+
+
+.selected-image {
+    height: 0;
+}
+
+.selected-image .edit-image, .selected-image legend {
+    display: none;
+}
+
+.selected-image .loading .imbo-spinner {
+    display: none;
+    height: 75px;
+    margin: 40px 185px;
+    width: 75px;
+}
+
+.selected-image img {
+    float: left;
+    margin: 0 10px 10px 0;
+    display: none;
+}
+
+/* IMAGE TOOLBAR */
+
+.image-toolbar {
     position: absolute;
-    bottom: 1%;
+    bottom: 0;
     left: 0;
     width: 100%;
-    background: #CCDCE8;
+    background: #dee2e5;
+    opacity: .4;
+    transition: opacity .4s;
+}
+
+.image-list li:hover .image-toolbar {
+    opacity: 1;
 }
 
 .image-toolbar button {
-    font-size: 2em;
     background: none;
     opacity: 0.6;
 }
@@ -191,6 +251,9 @@ fieldset.current-images {
 .image-list li:hover .image-toolbar {
     display: block;
 }
+
+
+/* Progress bar */
 
 .progress {
     margin: -31px 0 10px 0;
@@ -241,43 +304,29 @@ fieldset.current-images {
 .progress .file:nth-child(9) { background: rgba(40, 24, 0, 0.1); }
 .progress .file:nth-child(9) .bar { background: rgb(40, 24, 0); }
 
-.meta-editor {
-    padding-top: 12px;
 
-}
 
-.meta-editor .tab-controller, .meta-editor .tab-controller li {
-    padding: 0;
-    margin: 0;
-    list-style-type: none;
-}
+/* AFTER CLICKING AN IMAGE, YOU're TAKEN TO THE EDITOR:  */
 
-.meta-editor .tab-controller li {
-    display: inline-block;
-}
 
-.meta-editor .tab-controller button {
-    font-size: 1.1em;
-    height: 2em;
-    margin-left: 6px;
-}
 
-.meta-editor fieldset, .image-editor fieldset {
-    padding: 3px 18px 3px 12px;
-    margin: 10px 5px;
-    border: none;
-}
+/* EDITOR / META INFO */
 
-.meta-editor fieldset input, .meta-editor fieldset textarea {
-    width: 100%;
-    border: 0;
-}
+/*
 
-.meta-editor .input-pane textarea {
-    height: 150px;
-    resize: none;
-    font-family: 'Open Sans', arial, sans-serif;
-}
+    Note:
+
+    Previously we had an image-editor and a meta-editor.
+    Now, all lives within the .image-editor, but meta stuff is wrapped in  .image-editor > .settings-pane > .settings-tab.meta > .meta-editor
+
+    So, now, these are the paths to the two different parts:
+
+    .image-editor > .settings-pane > .settings-tab.image
+    .image-editor > .settings-pane > .settings-tab.meta > .meta-editor >.tabs
+    .image-editor > .image-container
+
+
+*/
 
 
 .meta-editor .image-container,
@@ -286,56 +335,29 @@ fieldset.current-images {
     float: left;
 }
 
-.meta-editor .tabs .active {
-    background: #999;
-    color: #000;
+
+
+
+/* META EDITOR */
+
+.meta-editor {
+    padding-top: 12px;
+
 }
 
-.meta-editor .input-pane legend,
-.image-editor .settings-pane legend {
-    font-size: 1.2em;
-}
-
-.meta-editor .input-pane legend .fa,
-.image-editor .settings-pane legend .fa {
-    margin: 0 7px;
-}
-
-.meta-editor .image-container {
-    width: 67.5%;
-    margin-left: 32.5%;
-    background: #F5F5F5 none no-repeat 50% 50%;
-    min-height: 400px;
-    border: 1px solid #000;
-    display: table;
-}
-
-.meta-editor .image-container .source {
-    display: table-cell;
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: 50% 50%;
-    width: 100%;
-    height: 100%;
-}
-
-.meta-editor .image-container h2, .image-editor .image-container h2 {
-    background: rgba(0, 0, 0, 0.5);
-    color: #fff;
-    padding: 5px 15px;
-    position: absolute;
-}
-
-.meta-editor .buttons, .image-editor .buttons {
+.meta-editor .buttons,
+.image-editor .buttons {
     padding: 10px;
     text-align: center;
 }
 
-.meta-editor .buttons button, .image-editor .buttons button {
+.meta-editor .buttons button,
+.image-editor .buttons button {
     font-size: 1.2em;
 }
 
-.meta-editor button.close, .image-editor button.close {
+.meta-editor button.close,
+.image-editor button.close {
 
     margin: 0 auto;
 }
@@ -360,24 +382,72 @@ fieldset.current-images {
 
 /* End of degrade styling */
 
-.meta-editor .exif-pane dl {
-    margin: 10px 10px 10px 20px;
-    color: #DDD;
+
+
+.meta-editor .tab-controller,
+.meta-editor .tab-controller li {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+}
+
+.meta-editor .tab-controller li {
+    display: inline-block;
+}
+
+.meta-editor .tab-controller button {
     font-size: 1.1em;
+    height: 2em;
+    margin-left: 6px;
 }
 
-.meta-editor .exif-pane dt {
-    font-weight: bold;
+.meta-editor .tabs .active {
+    background: #999;
+    color: #000;
 }
 
-.image-editor fieldset legend {
-    color: #CCC;
+
+
+.meta-editor fieldset,
+.image-editor fieldset {
+    padding: 3px 18px 3px 12px;
+    margin: 10px 5px;
+    border: none;
 }
 
-.image-editor button {
-    color: #ccc;
-    background-color: #333;
-    border: solid #666 1px;
+.meta-editor fieldset input,
+.meta-editor fieldset textarea {
+    width: 100%;
+    border: 0;
+}
+
+
+.meta-editor .input-pane textarea {
+    height: 150px;
+    resize: none;
+    font-family: 'Open Sans', arial, sans-serif;
+}
+
+
+
+.meta-editor .input-pane legend,
+.image-editor .settings-pane legend {
+    font-size: 1.2em;
+}
+
+.meta-editor .input-pane legend .fa,
+.image-editor .settings-pane legend .fa {
+    margin: 0 7px;
+}
+
+/* This wouldn't hit anything?
+.meta-editor .image-container {
+    width: 67.5%;
+    margin-left: 32.5%;
+    background: #F5F5F5 none no-repeat 50% 50%;
+    min-height: 400px;
+    border: 1px solid #000;
+    display: table;
 }
 
 .image-editor .image-container {
@@ -385,6 +455,74 @@ fieldset.current-images {
     min-height: 400px;
     margin-top: 13px;
 }
+
+.meta-editor .image-container .source {
+    display: table-cell;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: 50% 50%;
+    width: 100%;
+    height: 100%;
+}
+
+.meta-editor .image-container h2, .image-editor .image-container h2 {
+    background: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    padding: 5px 15px;
+    position: absolute;
+}
+*/
+
+
+
+/* STYLING LIST OF EXIF DATA: */
+
+/* clearfix */
+.meta-editor .exif-pane dl:after {
+    content: "";
+    display: table;
+    clear: both;
+}
+
+.meta-editor .exif-pane	dl {
+    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    clear: both;
+    width: 100%;
+    margin: 20px 0;
+    padding: 0;
+    border-bottom: 1px solid #6b6b6b;
+}
+
+.meta-editor .exif-pane dl dt {
+    clear: both;
+    width: 43%;
+    float: left;
+    margin: 0;
+    padding: 6px 1% 4px 4%;
+    font-weight: 600;
+    border-top: 1px solid #6b6b6b;
+}
+
+.meta-editor .exif-pane dl dd {
+    float: left;
+    width: 50%;
+    margin: 0;
+    padding: 6px 1%;
+    border-top: 1px solid #6b6b6b;
+}
+
+.image-editor fieldset legend {
+    color: #ccc;
+}
+
+.image-editor button {
+    color: #ccc;
+    background-color: #333;
+    border: 1px solid #666;
+}
+
+
 
 .image-editor .controls label {
     display: block;

--- a/css/imbo-plugin.css
+++ b/css/imbo-plugin.css
@@ -4,18 +4,6 @@ body.editor-view {
     color: #ccc;
 }
 
-
-.content > fieldset {
-    margin: 0;
-    padding: 6px 12px;
-    border: none;
-}
-
-.content  fieldset legend {
-    margin: 6px 0 0 0;
-    font-size: 15px;
-}
-
 /* Override default background color on buttons */
 input[type="button"],
 input[type="submit"],
@@ -24,23 +12,126 @@ button, div.button {
 }
 
 
-/* Utility classes */
-
-.droppable {
-    background: #baeebc;
+/* Aptoma defaults for fieldsets */
+fieldset {
+    margin: 15px 0;
+    padding: 20px 12px;
+    min-height: 60px;
+    border: none;
+    border-bottom: solid 1px #dfdfdf;
 }
 
-.hidden {
-    display: none !important;
+/* Style labels, legends and subtitles */
+label,
+fieldset h3,
+fieldset legend {
+    font-size: 15px;
+    color: #666;
 }
 
-.clear:before, .clear:after {
-    content: " ";
-    display: table;
+fieldset h3 {
+    margin-top: 10px;
 }
 
-.clear:after {
-    clear: both;
+
+/* Fieldset for adding new images */
+fieldset.add-new-images {
+    position: relative;
+}
+
+
+/* Override fieldset defaults for selected image (when not visible) */
+.selected-image {
+    min-height: 0;
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
+.selected-image .edit-image,
+.selected-image legend {
+    display: none;
+}
+
+/* Fieldset with list of images */
+fieldset.current-images {
+    padding-right: 0;
+}
+
+/* Fieldsets within settings-pane */
+
+.settings-pane fieldset {
+    padding: 3px 18px 3px 12px;
+    margin: 10px 5px;
+    border: none;
+}
+
+.settings-pane label,
+.settings-pane fieldset h3,
+.settings-pane fieldset legend {
+    color: #ccc;
+}
+
+
+/* Styling inputs and text areas */
+input[type="text"],
+input[type="search"],
+textarea {
+    display: block;
+    width: 90%;
+    margin-bottom: 10px;
+    padding: 5px 10px;
+    font-family: 'Open Sans', arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.42857;
+
+    -webkit-transition: border-color ease-in-out 0.15s,box-shadow ease-in-out 0.15s;
+    transition: border-color ease-in-out 0.15s,box-shadow ease-in-out 0.15s;
+}
+
+
+/* Specify colors for inputs in light grey panel */
+
+.search input[type="text"],
+.search input[type="search"] {
+    width: 60%;
+    float: left;
+    color: #444;
+    background: #fff;
+    border: 1px solid #9db1c2;
+}
+
+.search input[type="text"]:focus,
+.search input[type="search"]:focus {
+    border-color: #4e6f8a;
+    outline: 0;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 5px rgba(78,111,138,0.4);
+}
+
+
+
+
+/* Specify colors for inputs in dark grey window */
+
+.settings-pane input[type="text"],
+.settings-pane input[type="search"],
+.settings-pane textarea {
+    width: 100%;
+    background: #ddd;
+    border: 1px solid #444;
+}
+
+.settings-pane textarea {
+    height: 150px;
+    resize: none;
+}
+
+.settings-pane input[type="text"]:focus,
+.settings-pane input[type="search"]:focus,
+.settings-pane textarea:focus {
+    border-color: #222;
+    outline: 0;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075), 0 0 5px rgba(0, 0, 0 ,0.4);
 }
 
 
@@ -58,15 +149,13 @@ button, div.button {
     display: block;
 }
 
+
+
+
 /* CONTENT - first panel (add image, choose image) */
 
 
 /* Adding new images */
-
-fieldset.add-new-images {
-    position: relative;
-    padding-bottom: 30px;
-}
 
 .file-upload {
     opacity: 0;
@@ -79,11 +168,12 @@ button.upload-scanpix-image {
     width: 225px;
     height: 30px;
     position: absolute;
+    font-size: 15px;
     cursor: pointer;
 }
 
 .file-upload, button.upload-local-file {
-    left: 10px;
+    left: 12px;
 }
 
 button.upload-scanpix-image {
@@ -94,30 +184,38 @@ button.upload-scanpix-image {
     opacity: 1;
 }
 
-fieldset.current-images {
-    padding: 0 0 0 12px;
-}
-
-
-.search .image-search {
-    width: 60%;
-    float: left;
-}
-
 .search button {
     margin-left: 5px;
 }
 
 .search-stats {
-    margin-bottom: 6px;
+    clear: both;
+    margin: 30px 0 0;
+    color: #665;
 }
 
 
 /* IMAGE LIST  */
 
+
+
+.selected-image .loading .imbo-spinner {
+    display: none;
+    height: 75px;
+    margin: 40px 185px;
+    width: 75px;
+}
+
+.selected-image img {
+    float: left;
+    margin: 0 10px 10px 0;
+    display: none;
+}
+
+
 .image-list {
     list-style-type: none;
-    margin: 0;
+    margin: 0 -5px; /* compensate for item margin */
     padding: 0;
     background: #F5F5F5;
     overflow-y: auto;
@@ -196,26 +294,6 @@ fieldset.current-images {
     display: inline;
 }
 
-.selected-image {
-    height: 0;
-}
-
-.selected-image .edit-image, .selected-image legend {
-    display: none;
-}
-
-.selected-image .loading .imbo-spinner {
-    display: none;
-    height: 75px;
-    margin: 40px 185px;
-    width: 75px;
-}
-
-.selected-image img {
-    float: left;
-    margin: 0 10px 10px 0;
-    display: none;
-}
 
 
 /* IMAGE TOOLBAR */
@@ -407,26 +485,6 @@ fieldset.current-images {
 
 
 
-.meta-editor fieldset,
-.image-editor fieldset {
-    padding: 3px 18px 3px 12px;
-    margin: 10px 5px;
-    border: none;
-}
-
-.meta-editor fieldset input,
-.meta-editor fieldset textarea {
-    width: 100%;
-    background: #ddd;
-    border: 0;
-}
-
-
-.meta-editor .input-pane textarea {
-    height: 150px;
-    resize: none;
-    font-family: 'Open Sans', arial, sans-serif;
-}
 
 
 
@@ -599,6 +657,28 @@ fieldset.current-images {
     width: 80%;
 }
 
+/* Utility classes */
+
+.droppable {
+    background: #baeebc;
+}
+
+.hidden {
+    display: none !important;
+}
+
+.clear:before, .clear:after {
+    content: " ";
+    display: table;
+}
+
+.clear:after {
+    clear: both;
+}
+
+
+
+
 
 /** MEDIA QUERIES **/
 @media all and (max-width: 546px) and (min-width: 370px) {
@@ -612,10 +692,3 @@ fieldset.current-images {
         width: 92%;
     }
 }
-
-.search-stats {
-    margin-bottom: 6px;
-}
-
-
-

--- a/css/imbo-plugin.css
+++ b/css/imbo-plugin.css
@@ -259,7 +259,7 @@ button.upload-scanpix-image {
     padding-bottom: 30px; /* will be occupied by image-toolbar */
     height: 130px;
     background: #fff;
-    border: 1px solid #DDD;
+    border: 1px solid #ddd;
 
     display: -webkit-flexbox;
     display: -ms-flexbox;
@@ -276,6 +276,12 @@ button.upload-scanpix-image {
     align-items: center;
     justify-content: center;
 }
+
+
+.image-list li.redmarked {
+    border-color: #f16b52;
+}
+
 
 .image-list .full-image {
     margin: 0 auto;
@@ -327,6 +333,16 @@ button.upload-scanpix-image {
 
 .image-list li:hover .image-toolbar {
     display: block;
+}
+
+/* redmarked toolbar */
+
+.image-list li.redmarked .image-toolbar {
+    background: #f6a191;
+}
+
+.image-list li.redmarked .image-toolbar button i {
+    color: #52150a;
 }
 
 

--- a/css/imbo-plugin.css
+++ b/css/imbo-plugin.css
@@ -196,8 +196,6 @@ fieldset.current-images {
     display: inline;
 }
 
-
-
 .selected-image {
     height: 0;
 }
@@ -218,6 +216,7 @@ fieldset.current-images {
     margin: 0 10px 10px 0;
     display: none;
 }
+
 
 /* IMAGE TOOLBAR */
 
@@ -418,6 +417,7 @@ fieldset.current-images {
 .meta-editor fieldset input,
 .meta-editor fieldset textarea {
     width: 100%;
+    background: #ddd;
     border: 0;
 }
 
@@ -522,95 +522,6 @@ fieldset.current-images {
     border: 1px solid #666;
 }
 
-
-
-.image-editor .controls label {
-    display: block;
-    font-size: 1.1em;
-    font-weight: normal;
-    margin: 10px;
-}
-
-.image-editor .rotate:first-of-type {
-    margin-left: 6px;
-}
-.image-editor .rotate {
-    font-size: 2em;
-    padding: 0.2em .4em 1.6em;
-}
-
-.image-editor .image-loading {
-
-}
-
-.image-editor .settings-pane {
-    margin-top: 12px;
-    width: 24.5%;
-}
-
-.image-editor .settings-pane > div {
-
-}
-
-.image-editor .crop-presets {
-    min-height: 40px;
-}
-
-.image-editor .crop-presets .ratio {
-    margin: 0 5px 5px 0;
-}
-
-.image-editor .crop-presets .active {
-    background: #333;
-    border-color: #999;
-}
-
-.image-editor .settings-pane input[type=range] {
-    display: block;
-    margin: 0 auto;
-    width: 80%;
-}
-
-.selected-image {
-    height: 0;
-}
-
-.selected-image .edit-image, .selected-image legend {
-    display: none;
-}
-
-.selected-image .loading .imbo-spinner {
-    display: none;
-    height: 75px;
-    margin: 40px 185px;
-    width: 75px;
-}
-
-.selected-image img {
-    float: left;
-    margin: 0 10px 10px 0;
-    display: none;
-}
-
-
-/** MEDIA QUERIES **/
-@media all and (max-width: 546px) and (min-width: 370px) {
-    .image-list li {
-        width: 46%;
-    }
-}
-
-@media all and (max-width: 369px) {
-    .image-list li {
-        width: 92%;
-    }
-}
-
-.search-stats {
-    margin-bottom: 6px;
-}
-
-
 .image-editor .settings-header {
     display:none;
     padding: 0 0 0 12px;
@@ -644,11 +555,67 @@ fieldset.current-images {
     margin: 0 12px;
 }
 
-
-.image-list .insert-image {
-    display: none;
+.image-editor .controls label {
+    display: block;
+    font-size: 1.1em;
+    font-weight: normal;
+    margin: 10px;
 }
 
-.image-list.insertion-enabled .insert-image {
-    display: inline;
+.image-editor .rotate:first-of-type {
+    margin-left: 6px;
 }
+.image-editor .rotate {
+    font-size: 2em;
+    padding: 0.2em .4em 1.6em;
+}
+
+
+.image-editor .settings-pane {
+    margin-top: 12px;
+    width: 24.5%;
+}
+
+.image-editor .settings-pane > div {
+
+}
+
+.image-editor .crop-presets {
+    min-height: 40px;
+}
+
+.image-editor .crop-presets .ratio {
+    margin: 0 5px 5px 0;
+}
+
+.image-editor .crop-presets .active {
+    background: #333;
+    border-color: #999;
+}
+
+.image-editor .settings-pane input[type=range] {
+    display: block;
+    margin: 0 auto;
+    width: 80%;
+}
+
+
+/** MEDIA QUERIES **/
+@media all and (max-width: 546px) and (min-width: 370px) {
+    .image-list li {
+        width: 46%;
+    }
+}
+
+@media all and (max-width: 369px) {
+    .image-list li {
+        width: 92%;
+    }
+}
+
+.search-stats {
+    margin-bottom: 6px;
+}
+
+
+

--- a/index.php
+++ b/index.php
@@ -170,10 +170,10 @@
 
     </section>
 
-    <div class="meta-info" style="position: absolute; top: 170px; z-index: 100; height: 400px; width: 205%; background: #222;">
+ <!--   <div class="meta-info" style="position: absolute; top: 170px; z-index: 100; height: 400px; width: 205%; background: #222;">
         <p>Her kommer meta-info</p>
     </div>
-
+-->
     <aside class="image-toolbar hidden">
         <button class="image-use" data-translate-title="USE_EDIT_IMAGE" data-action="use-image">
             <i class="material-icons add">add_circle_outline</i>

--- a/index.php
+++ b/index.php
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="css/font-awesome.min.css">
     <link rel="stylesheet" href="css/imbo-loader.css">
     <link rel="stylesheet" href="css/imbo-plugin.css?<?php echo time(); ?>">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <script>
         var Drp = window.Drp || {};
         Drp.ImboConfig = <?php echo json_encode($config); ?>;
@@ -31,7 +32,6 @@
             <input type="file" name="files[]" accept="image/*" class="file-upload"  multiple>
             <button class="upload-local-file"><i class="fa fa-upload"></i> <span data-translate="UPLOAD_LOCAL_IMAGE"></span></button>
             <button class="upload-scanpix-image"><i class="fa fa-upload"></i> <span data-translate="LOAD_FROM_SCANPIX"></span></button>
-            <span class="spacer">&nbsp;</span>
 
             <div class="progress clear hidden"></div>
         </fieldset>
@@ -126,37 +126,31 @@
 
             <div class="settings-tab meta">
                 <div class="meta-editor">
-                            <div class="tabs">
-                                <ul class="tab-controller">
-                                    <li><button class="core active" data-tab="core"><i class="fa fa-info"></i> <span data-translate="META_EDITOR_CORE_TAB"></span></button></li>
-                                    <li><button class="exif" data-tab="exif"><i class="fa fa-picture-o"></i> <span data-translate="META_EDITOR_EXIF_TAB"></span></button></li>
-                                </ul>
+                    <div class="tabs">
+                        <ul class="tab-controller">
+                            <li><button class="core active" data-tab="core"><i class="fa fa-info"></i> <span data-translate="META_EDITOR_CORE_TAB"></span></button></li>
+                            <li><button class="exif" data-tab="exif"><i class="fa fa-picture-o"></i> <span data-translate="META_EDITOR_EXIF_TAB"></span></button></li>
+                        </ul>
 
-                                <section class="input-pane tab" data-tab="core">
-                                    <fieldset>
-                                        <legend data-translate="META_EDITOR_IMAGE_TITLE"></legend>
-                                        <input type="text" name="drp:title">
-                                    </fieldset>
+                        <section class="input-pane tab" data-tab="core">
+                            <fieldset>
+                                <h3 data-translate="META_EDITOR_IMAGE_TITLE"></h3>
+                                <input type="text" name="drp:title">
 
-                                    <fieldset>
-                                        <legend data-translate="META_EDITOR_IMAGE_DESCRIPTION"></legend>
-                                        <textarea name="drp:description"></textarea>
-                                    </fieldset>
+                                <h3 data-translate="META_EDITOR_IMAGE_DESCRIPTION"></h3>
+                                <textarea name="drp:description"></textarea>
 
-                                    <fieldset>
-                                        <legend data-translate="META_EDITOR_IMAGE_PHOTOGRAPHER"></legend>
-                                        <input type="text" name="drp:photographer">
-                                    </fieldset>
+                                <h3 data-translate="META_EDITOR_IMAGE_PHOTOGRAPHER"></h3>
+                                <input type="text" name="drp:photographer">
 
-                                    <fieldset>
-                                        <legend data-translate="META_EDITOR_IMAGE_AGENCY"></legend>
-                                        <input type="text" name="drp:agency">
-                                    </fieldset>
-                                </section>
+                                <h3 data-translate="META_EDITOR_IMAGE_AGENCY"></h3>
+                                <input type="text" name="drp:agency">
+                            </fieldset>
+                        </section>
 
-                                <section class="exif-pane tab hidden" data-tab="exif">
-                                    &nbsp;
-                                </section>
+                        <section class="exif-pane tab hidden" data-tab="exif">
+                            &nbsp;
+                        </section>
 
                                 <div class="buttons">
                                     <button class="close"><i class="fa fa-times"></i> <span data-translate="IMAGE_EDITOR_CANCEL_BUTTON"></span></button>
@@ -175,11 +169,11 @@
 
     <aside class="image-toolbar hidden">
         <button class="image-use" data-translate-title="USE_EDIT_IMAGE" data-action="use-image">
-            <span class="insert-image"><i class="fa fa-plus-square-o"></i>/</span><i class="fa fa-edit"></i>
+            <i class="material-icons">add_circle_outline</i>
         </button>
-<!--        <button data-translate-title="SHOW_IMAGE_INFO" data-action="show-image-info"><i class="fa fa-info"></i></button>-->
-        <a href="#download-link" class="download-image" download="#file-name"><button data-translate-title="DOWNLOAD_IMAGE" data-action="download-image"><i class="fa fa-download"></i></button></a>
-        <button class="image-delete" data-translate-title="DELETE_IMAGE" data-action="delete-image"><i class="fa fa-trash-o"></i></button>
+        <button data-translate-title="SHOW_IMAGE_INFO" data-action="show-image-info"><i class="material-icons">info_outline</i></button>
+        <a href="#download-link" class="download-image" download="#file-name"><button data-translate-title="DOWNLOAD_IMAGE" data-action="download-image"><i class="material-icons">file_download</i></button></a>
+        <button class="image-delete" data-translate-title="DELETE_IMAGE" data-action="delete-image"><i class="material-icons">delete</i></button>
     </aside>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -170,12 +170,16 @@
 
     </section>
 
+    <div class="meta-info" style="position: absolute; top: 170px; z-index: 100; height: 400px; width: 205%; background: #222;">
+        <p>Her kommer meta-info</p>
+    </div>
+
     <aside class="image-toolbar hidden">
         <button class="image-use" data-translate-title="USE_EDIT_IMAGE" data-action="use-image">
-            <i class="material-icons">add_circle_outline</i>
+            <i class="material-icons add">add_circle_outline</i>
         </button>
-        <button data-translate-title="SHOW_IMAGE_INFO" data-action="show-image-info"><i class="material-icons">info_outline</i></button>
-        <a href="#download-link" class="download-image" download="#file-name"><button data-translate-title="DOWNLOAD_IMAGE" data-action="download-image"><i class="material-icons">file_download</i></button></a>
+        <button data-translate-title="SHOW_IMAGE_INFO" data-action="show-image-info"><i class="material-icons info">info_outline</i></button>
+        <a href="#download-link" class="download-image" download="#file-name"><button data-translate-title="DOWNLOAD_IMAGE" data-action="download-image"><i class="material-icons download">file_download</i></button></a>
         <button class="image-delete" data-translate-title="DELETE_IMAGE" data-action="delete-image"><i class="material-icons">delete</i></button>
     </aside>
 </body>

--- a/index.php
+++ b/index.php
@@ -54,13 +54,13 @@
                 <button type="submit"><i class="fa fa-search"></i> <span data-translate="IMAGE_SEARCH_BUTTON"></span></button>
                 <button type="button" class="refresh"><i class="fa fa-refresh"></i> <span data-translate="IMAGE_SEARCH_REFRESH_BUTTON"></span></button>
             </form>
-            <div class="search-stats">
+            <p class="search-stats">
                 <span data-translate="IMAGE_RESULT_SHOWING"></span>
                 <span class="display-count">0</span>
                 <span data-translate="IMAGE_RESULT_OUT_OF"></span>
                 <span class="total-hit-count">0</span>
-                <span data-translate="IMAGE_RESULT_TOTAL_HITS"></span>
-            </div>
+                <span data-translate="IMAGE_RESULT_TOTAL_HITS"></span>:
+            </p>
 
             <ul class="image-list clear"></ul>
         </fieldset>

--- a/index.php
+++ b/index.php
@@ -170,17 +170,34 @@
 
     </section>
 
- <!--   <div class="meta-info" style="position: absolute; top: 170px; z-index: 100; height: 400px; width: 205%; background: #222;">
-        <p>Her kommer meta-info</p>
-    </div>
--->
+
+
     <aside class="image-toolbar hidden">
+
         <button class="image-use" data-translate-title="USE_EDIT_IMAGE" data-action="use-image">
             <i class="material-icons add">add_circle_outline</i>
         </button>
         <button data-translate-title="SHOW_IMAGE_INFO" data-action="show-image-info"><i class="material-icons info">info_outline</i></button>
         <a href="#download-link" class="download-image" download="#file-name"><button data-translate-title="DOWNLOAD_IMAGE" data-action="download-image"><i class="material-icons download">file_download</i></button></a>
         <button class="image-delete" data-translate-title="DELETE_IMAGE" data-action="delete-image"><i class="material-icons">delete</i></button>
+
+        <div class="meta-info"> <!-- if image has restrictions, add class "restrictions" + if credit = VG, add class "vg", if other than VG, add "agency" - if no credit is given, add class "nocredit". I think. -->
+            <p>$filename</p>
+
+            <dl>
+                <dt>Restrictions</dt> <!-- only display if there ARE restrictions -->
+                <dd class="restrictions">$restriction-text</dd> <!-- only display if there ARE restrictions -->
+
+                <dt>Caption</dt>
+                <dd class="caption">$caption-text</dd>
+
+                <dt>Date:</dt>
+                <dd>$date DD.MM.YYYY HH:MM</dd>
+
+                <dt>Scanpix-ID</dt>
+                <dd>$scanpix-id</dd>
+        </div>
+
     </aside>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -68,6 +68,11 @@
 
 
     <section class="image-editor hidden">
+
+        <section class="image-container">
+            <img src="img/blank.gif" id="image-preview" alt="">
+        </section>
+
         <div class="settings-pane">
             <div class="settings-header">
                 <button data-ref="image" >
@@ -162,9 +167,7 @@
 
         </div>
 
-        <section class="image-container">
-            <img src="img/blank.gif" id="image-preview" alt="">
-        </section>
+
     </section>
 
     <aside class="image-toolbar hidden">

--- a/js/language/no.js
+++ b/js/language/no.js
@@ -30,7 +30,7 @@ define(['underscore', 'language/en'], function(_, english) {
         'META_EDITOR_IMAGE_TITLE': 'Tittel',
         'META_EDITOR_IMAGE_DESCRIPTION': 'Beskrivelse',
         'META_EDITOR_IMAGE_PHOTOGRAPHER': 'Fotograf',
-        'META_EDITOR_IMAGE_AGENCY': 'Agentur',
+        'META_EDITOR_IMAGE_AGENCY': 'Byrå',
         'META_EDITOR_IMAGE_EXIF': 'EXIF-data',
         'META_EDITOR_SOURCE_IMAGE': 'Originalbilde',
         'META_EDITOR_SAVE_META_DATA': 'Lagre bildeinformasjon',


### PR DESCRIPTION
- Adjust and align whitespace, margins etc. in initial plugin content view

- Update presentation of image list, including new icons

- Add styling of `.redmarked` images in `.image-list`

- Move image-container to the left in edit mode (to mirror content/panels position in rest of Dr. Pub)

- Add placeholder container for adding meta info to images in `.image-list`.

- Cleanup CSS file, adding comments for easier navigation

- A bunch of minor tweaks
