### PR TITLE
Scale jcrop instance based on window size

### DIFF
--- a/css/imbo-plugin.css
+++ b/css/imbo-plugin.css
@@ -447,7 +447,10 @@ button.upload-scanpix-image {
     float: left;
 }
 
-
+/* Hack to avoid jcrop overlaying other content. Happens sometimes :( */
+.image-editor .image-container .jcrop-holder {
+    overflow: hidden;
+}
 
 
 /* META EDITOR */

--- a/js/app.js
+++ b/js/app.js
@@ -275,7 +275,6 @@ define([
         },
 
         bindEvents: function () {
-
             this.window
                 .on('resize', _.debounce(this.onWindowResize, 100))
                 .trigger('resize');

--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -125,15 +125,9 @@ define([
         },
 
         getPreviewContainerSize: function getPreviewContainerSize() {
-            var width = $(window).width() - $('.settings-pane').width();
-            var height = $(window).height();
-
-            var widthSafetyMargin = Math.min(width * 0.1, 50);
-            var heightSafetyMargin = Math.min(height * 0.1, 20);
-
             return [
-                width - widthSafetyMargin,
-                height - heightSafetyMargin
+                $(window).width() - $('.settings-pane').width(),
+                $(window).height()
             ];
         },
 


### PR DESCRIPTION
This PR adds logic to scale jcrop instance based on window size to avoid large images on small screens and vice versa.