### PR TITLE
Remove `drp:`-prefix from metadata fields

### DIFF
--- a/index.php
+++ b/index.php
@@ -140,16 +140,16 @@
                         <section class="input-pane tab" data-tab="core">
                             <fieldset>
                                 <h3 data-translate="META_EDITOR_IMAGE_TITLE"></h3>
-                                <input type="text" name="drp:title">
+                                <input type="text" name="title">
 
                                 <h3 data-translate="META_EDITOR_IMAGE_DESCRIPTION"></h3>
-                                <textarea name="drp:description"></textarea>
+                                <textarea name="description"></textarea>
 
                                 <h3 data-translate="META_EDITOR_IMAGE_PHOTOGRAPHER"></h3>
-                                <input type="text" name="drp:photographer">
+                                <input type="text" name="photographer">
 
                                 <h3 data-translate="META_EDITOR_IMAGE_AGENCY"></h3>
-                                <input type="text" name="drp:agency">
+                                <input type="text" name="agency">
                             </fieldset>
                         </section>
 

--- a/js/app.js
+++ b/js/app.js
@@ -627,7 +627,7 @@ define([
 
         buildImageListItem: function (html, image) {
             // Get file name
-            var fileName = image.metadata['drp:filename'] || [image.imageIdentifier, image.extension].join('.');
+            var fileName = image.metadata['filename'] || [image.imageIdentifier, image.extension].join('.');
 
             // Build query string
             var queryString = [
@@ -643,7 +643,7 @@ define([
 
             var full = url.toString(),
                 thumb = url.maxSize({width: 158, height: 158}).jpg().toString(),
-                name = image.metadata['drp:filename'] || image.imageIdentifier,
+                name = image.metadata['filename'] || image.imageIdentifier,
                 el = '';
 
             var containerClass = (

--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -477,10 +477,10 @@ define([
                 imboOptions: {
                     imageIdentifier: this.imageIdentifier,
                     externalId: this.imageIdentifier,
-                    title: this.imageMetadata['drp:title'] || '',
-                    description: this.imageMetadata['drp:description'] || '',
-                    author: this.imageMetadata['drp:photographer'] || '',
-                    source: this.imageMetadata['drp:agency'] || '',
+                    title: this.imageMetadata['title'] || '',
+                    description: this.imageMetadata['description'] || '',
+                    author: this.imageMetadata['photographer'] || '',
+                    source: this.imageMetadata['agency'] || '',
                     cropParams: this.cropParams,
                     cropRatio: this.cropAspectRatio,
                     transformations: this.buildImageUrl().getTransformations()
@@ -508,10 +508,10 @@ define([
                 renditions: this.buildRenditions(),
                 imboOptions: {
                     imageIdentifier: this.imageIdentifier,
-                    title: this.imageMetadata['drp:title'] || '',
-                    description: this.imageMetadata['drp:description'] || '',
-                    author: this.imageMetadata['drp:photographer'] || '',
-                    source: this.imageMetadata['drp:agency'] || '',
+                    title: this.imageMetadata['title'] || '',
+                    description: this.imageMetadata['description'] || '',
+                    author: this.imageMetadata['photographer'] || '',
+                    source: this.imageMetadata['agency'] || '',
                     cropParams: this.cropParams,
                     cropRatio: this.cropAspectRatio,
                     transformations: this.buildImageUrl().getTransformations()

--- a/js/meta-editor.js
+++ b/js/meta-editor.js
@@ -127,9 +127,9 @@ define([
                 var name = el.getAttribute('name');
                 if (data[name]) {
                     el.value = data[name];
-                } else if (name === 'drp:title' && data['drp:filename']) {
-                    el.value = data['drp:filename'];
-                } else if (name === 'drp:photographer' && data['exif:Artist']) {
+                } else if (name === 'title' && data['filename']) {
+                    el.value = data['filename'];
+                } else if (name === 'photographer' && data['exif:Artist']) {
                     el.value = data['exif:Artist'];
                 }
             });

--- a/js/uploader.js
+++ b/js/uploader.js
@@ -31,7 +31,7 @@ define(['underscore', 'jquery', 'async', 'draghover'], function (_, $, async) {
         setUserInfo: function (userInfo) {
             this.user = userInfo;
             this.userMeta = {
-                'drp:uploader': {
+                'uploader': {
                     'fullname': userInfo.fullname,
                     'username': userInfo.username
                 }
@@ -124,7 +124,7 @@ define(['underscore', 'jquery', 'async', 'draghover'], function (_, $, async) {
 
         prepareScanpixMetadata: function(image) {
             var metadata = {
-                'drp:description': image.caption,
+                'description': image.caption,
 
                 'byline': image.byline,
                 'description': image.caption,
@@ -208,7 +208,7 @@ define(['underscore', 'jquery', 'async', 'draghover'], function (_, $, async) {
 
             // Edit metadata for image
             var metadata = _.merge({}, this.userMeta, taskMetadata, {
-                'drp:filename': filename || imageIdentifier
+                'filename': filename || imageIdentifier
             });
 
             // Add additional metadata to the image


### PR DESCRIPTION
We're now using these fields in the metadata search, so unprefixing them makes more sense now since they're not "protected" (no longer for "exclusive use" in drpublish)