### PR TITLE
Publication image sizes

### DIFF
--- a/config/config.php.dist
+++ b/config/config.php.dist
@@ -19,6 +19,16 @@ $publicationUserMapping = [
     ]
 ];
 
+// Mapping between publication and image sizes. Each publication can define their own
+// set of sizes. The settings here then propogates to the editor and allowing the
+// journalists to choose. If publication array is empty or not defined, default
+// values, defined in app.js, will be used
+$publicationImageSizeMapping = [
+    '1337' => [
+        ['name' => 'default', 'width' => 654]
+    ],
+];
+
 /**
  * Build the config array with data from the base config and the publication user mapping
  *

--- a/index.php
+++ b/index.php
@@ -28,7 +28,7 @@
         var Drp = window.Drp || {};
         Drp.ImboConfig = <?php echo json_encode($config); ?>;
     </script>
-    <script src="vendor/require-2.1.11.min.js" data-main="js/main"></script>
+    <script src="vendor/require-2.1.11.min.js" data-main="js/main.js?<?=time()?>"></script>
 </head>
 <body class="loading standalone">
     <?php include 'imbo-loader.html'; ?>

--- a/js/app.js
+++ b/js/app.js
@@ -135,7 +135,7 @@ define([
 
             PluginAPI.Editor.getHTMLById(id, function (html) {
                 var el = $(html),
-                    img = el.find('img[data-transformations]');
+                    img = el.find('img');
 
                 // Remove all existing floats
                 el.removeClass(floats.join(' '));

--- a/js/app.js
+++ b/js/app.js
@@ -111,7 +111,11 @@ define([
 
         setConfig: function (config) {
             this.config = config || {};
-            this.imageSizes = ImboApp.DEFAULT_IMAGE_SIZES || [];
+            this.config.imageSizes = this.config.imbo.imageSizes;
+
+            if (!this.config.imageSizes || !this.config.imageSizes.length) {
+                this.config.imageSizes = ImboApp.DEFAULT_IMAGE_SIZES;
+            }
         },
 
         setHelpers: function (helpers) {
@@ -119,7 +123,7 @@ define([
         },
 
         getImageResizeActions: function () {
-            var actions = [], sizes = this.imageSizes;
+            var actions = [], sizes = this.config.imageSizes;
             for (var i = 0; i < sizes.length; i++) {
                 actions.push({
                     label: sizes[i].name,

--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -690,13 +690,21 @@ define([
         insertEmbeddedImage: function () {
             PluginAPI.showLoader('Importing image...')
 
+            var defaultWidth;
+            var defaultImageSize = _.find(this.imboApp.config.imageSizes, function(size) { return size.name === 'default' });
+            if (defaultImageSize) {
+                defaultWidth = defaultImageSize.width;
+            } else {
+                defaultWidth = this.imboApp.config.imageSizes[0];
+            }
+
             var options = {
                 embeddedTypeId: this.embeddedTypeId,
                 externalId: this.imageIdentifier,
                 assetClass: this.imageClassName,
                 resourceUri: this.buildImageUrl().jpg().toString(),
-                previewUri: this.buildImageUrl().maxSize({width: 552}).jpg().toString(),
-                previewWidth: 552,
+                previewUri: this.buildImageUrl().maxSize({width: defaultWidth}).jpg().toString(),
+                previewWidth: defaultWidth,
                 renditions: this.buildRenditions(),
                 imboOptions: {
                     imageIdentifier: this.imageIdentifier,

--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -762,7 +762,11 @@ define([
         },
 
         buildRenditions: function () {
-            var renditions = {};
+            var renditions = {
+                highRes: {
+                    uri: this.buildImageUrl().reset().jpg().toString()
+                }
+            };
             _.each(this.imboApp.config.imageSizes, _.bind(function(size) {
                 var maxSizeOptions = {};
                 if (size.width) {

--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -762,15 +762,21 @@ define([
         },
 
         buildRenditions: function () {
-            var thumbnailUri = this.buildImageUrl().maxSize({width: 100, height: 100}).jpg().toString();
-            var previewUri = this.buildImageUrl().maxSize({width: 800, height: 800}).jpg().toString();
-            var highResUrl = this.buildImageUrl().jpg().toString();
+            var renditions = {};
+            _.each(this.imboApp.config.imageSizes, _.bind(function(size) {
+                var maxSizeOptions = {};
+                if (size.width) {
+                    maxSizeOptions.width = size.width;
+                }
+                if (size.height) {
+                    maxSizeOptions.height = size.height;
+                }
 
-            return {
-                highRes: {uri: highResUrl},
-                preview: {uri: previewUri},
-                thumbnail: {uri: thumbnailUri}
-            }
+                var uri = this.buildImageUrl().maxSize(maxSizeOptions).jpg().toString();
+                renditions[size.name] = { uri: uri };
+            }, this));
+
+            return renditions;
         },
 
         onEditorSelectImage: function (elementId, data) {

--- a/js/main.js
+++ b/js/main.js
@@ -37,7 +37,8 @@ require.config({
             deps: ['jquery', 'postmessage', 'drp-plugin-api'],
             exports: 'PluginAPI.Article'
         }
-    }
+    },
+    urlArgs: 'cachebreaker=' + (new Date()).getTime()
 });
 
 require([


### PR DESCRIPTION
Allow each publication to define their own image sizes. https://github.com/aptoma/drpublish-imbo-app/issues/1

When resizing images use img-selector instead img[data-transformations]

Also added cachebreaking of javascript.