### PR TITLE
Set correct imageWidth when size with name "default" is not defined

### DIFF
--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -724,8 +724,10 @@ define([
                 var defaultImageSize = _.find(this.imboApp.config.imageSizes, function(size) { return size.name === 'default' });
                 if (defaultImageSize) {
                     defaultWidth = defaultImageSize.width;
+                } else if(this.imboApp.config.imageSizes.length) {
+                    defaultWidth = this.imboApp.config.imageSizes[0].width;
                 } else {
-                    defaultWidth = this.imboApp.config.imageSizes[0];
+                    defaultWidth = 590;
                 }
 
                 var options = {


### PR DESCRIPTION
Fallback to 590 if no widths are found.