### PR TITLE
Avoid nested containers when updating an image

### DIFF
--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -712,7 +712,7 @@ define([
                 PluginAPI.Editor.getHTMLById(this.selectedElementId, function (html) {
                     var $asset = $(html);
                     $asset.find('img').attr('src', this.buildImageUrl().maxSize({width: defaultWidth}).jpg().toString());
-                    insertMarkup($asset[0].outerHTML, {
+                    insertMarkup($asset[0].innerHTML, {
                         imboOptions: {
                             imageIdentifier: this.imageIdentifier,
                             user: this.getUser(),


### PR DESCRIPTION
Reproducer:

1. Insert an image into an article.
2. Right-click the image, select 'Edit image', then 'Update image' in the editor.
3. Repeat this a couple of times.
4. Inspect the DOM in the editor. The image is nested in a series of plugin element containers.

When DrPublish inserts a plugin element, it wraps it in a container. When IMBO updates an image, it sends the plugin element *and* its container to DrPublish, where it is wrapped in another container. And so on.

Switching from `outerHTML` to `innerHTML` seems to fix this problem.