### PR TITLE
Fix issue where a newly inserted asset could not be autoselected

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -823,6 +823,7 @@ define([
                 options: options.imboOptions
             };
             PluginAPI.Editor.insertEmbeddedAsset(markup, data, callback);
+            return data;
         },
 
         exportAssetImage: function (options, callback) {

--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -694,10 +694,10 @@ define([
                 var onDone = function () {
                     PluginAPI.hideLoader();
                     this.hide();
-                    PluginAPI.Editor.markAsActive(this.selectedElementId);
-                    this.onEditorSelectImage(this.selectedElementId, options.imboOptions);
+                    PluginAPI.Editor.markAsActive(options.internalId);
+                    this.onEditorSelectImage(options.internalId, options.options);
                 }.bind(this);
-                this.imboApp.exportEmbeddedAsset(markup, options, onDone);
+                options = this.imboApp.exportEmbeddedAsset(markup, options, onDone);
             }.bind(this);
 
             var defaultWidth = 590;


### PR DESCRIPTION
In the callback for the function which inserted an embedded asset, there was an attempt to select the newly inserted image using `this.selectedElementId`. This could never work, as `this.selectedElementId` is reset by the call to `this.hide()` (which again calls `this.reset()` etc) two lines up.

But even if it wasn't reset, there's nothing that could cause `this.selectedElementId` to be populated by the ID of the newly inserted asset.

This PR ensures that a newly created embedded asset is properly selected and marked when the insertion is complete. We now return the data object which receives the assigned asset ID and use it in the calls to `markAsActive` and `onEditorSelectImage`.