### PR TITLE
Fix issue where insertion could be aborted due to incorrect selection

### DIFF
--- a/js/image-editor.js
+++ b/js/image-editor.js
@@ -711,19 +711,27 @@ define([
             if (this.selectedElementId) {
                 PluginAPI.Editor.getHTMLById(this.selectedElementId, function (html) {
                     var $asset = $(html);
-                    $asset.find('img').attr('src', this.buildImageUrl().maxSize({width: defaultWidth}).jpg().toString());
-                    insertMarkup($asset[0].innerHTML, {
-                        imboOptions: {
-                            imageIdentifier: this.imageIdentifier,
-                            user: this.getUser(),
-                            externalId: this.imageIdentifier,
-                            cropParams: this.cropParams,
-                            cropRatio: this.cropAspectRatio,
-                            transformations: this.buildImageUrl().getTransformations()
-                        }
-                    });
+                    if ($asset.length) {
+                        $asset.find('img').attr('src', this.buildImageUrl().maxSize({width: defaultWidth}).jpg().toString());
+                        insertMarkup($asset[0].innerHTML, {
+                            imboOptions: {
+                                imageIdentifier: this.imageIdentifier,
+                                user: this.getUser(),
+                                externalId: this.imageIdentifier,
+                                cropParams: this.cropParams,
+                                cropRatio: this.cropAspectRatio,
+                                transformations: this.buildImageUrl().getTransformations()
+                            }
+                        });
+                    } else {
+                        insertNewEmbed.bind(this)();
+                    }
                 }.bind(this));
             } else {
+                insertNewEmbed.bind(this)();
+            }
+
+            function insertNewEmbed() {
                 var options = {
                     embeddedTypeId: this.embeddedTypeId,
                     externalId: this.imageIdentifier,
@@ -747,7 +755,6 @@ define([
                 };
                 insertMarkup(template(options), options);
             }
-
         },
 
         insertAssetImage: function () {


### PR DESCRIPTION
If `this.selectedElementId` contains a value, but no element with that ID can be found in the editor, the insert will just break. Usually when this happens, it's the result of an element having been removed, without also properly clearing `this.selectedElementId`.

This PR ensures that if `this.selectedElementId` points to nothing, the insert will continue, and create a new embedded asset at the cursor position, as expected.
